### PR TITLE
Better undefined check

### DIFF
--- a/src/vagueTime.js
+++ b/src/vagueTime.js
@@ -17,7 +17,7 @@
         minute: 60000 // 1000 ms * 60 s
     };
 
-    if (exports) {
+    if (typeof(exports) !== "undefined") {
         exports.get = getVagueTime;
     } else {
         window.vagueTime = {


### PR DESCRIPTION
This is a more reliable way for checking if exports is undefined and prevents errors in some browsers.
