### PR TITLE
Use unminified source code with component

### DIFF
--- a/component.json
+++ b/component.json
@@ -9,9 +9,9 @@
         { "name": "seth-cameo" },
         { "name": "Pepijn de Vos" }
     ],
-    "main": "src/vagueTime.min.js",
+    "main": "src/vagueTime.js",
     "scripts": [
-        "src/vagueTime.min.js"
+        "src/vagueTime.js"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
Components are usually minified after the build process.

This helps debug issues in the source. For example, I couldn't find out why vagueTime wasn't working as a component, I went to throw in a few breakpoints, and found the minified version.
