### PR TITLE
Fix component definition

### DIFF
--- a/component.json
+++ b/component.json
@@ -4,6 +4,7 @@
     "description": "A tiny library that formats precise time differences as a vague/fuzzy time, e.g. '3 months ago', 'just now' or 'in 2 hours'.",
     "repo": "philbooth/vagueTime.js",
     "license": "MIT",
+    "main": "src/vagueTime.js",
     "keywords": [
         "time",
         "date",
@@ -12,7 +13,7 @@
         "estimate"
     ],
     "scripts": [
-        "src/vagueTime.min.js"
+        "src/vagueTime.js"
     ]
 }
 


### PR DESCRIPTION
It seems the "main" field got lost in `component.json`, and it's a requirement when using a non-standard filename. See [here](https://github.com/component/component/wiki/Spec#wiki-main).

Also, I switched back to using the unminified version, which was merged in #5 but was also lost for some reason.
