### PR TITLE
Fix AMD module exports

### DIFF
--- a/src/vagueTime.js
+++ b/src/vagueTime.js
@@ -116,8 +116,8 @@
 
     function exportFunctions () {
         if (typeof define === 'function' && define.amd) {
-            define(function () {
-                return functions;
+            define('vagueTime', ['exports'], function(exports) {
+                exports.get = functions.get;
             });
         } else if (typeof module !== 'undefined' && module !== null) {
             module.exports = functions;


### PR DESCRIPTION
anonymous amd module definition with RequireJS throw a error, then we go explicitly declare the module :)